### PR TITLE
Implement login roles and user management

### DIFF
--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -7,7 +7,7 @@ import Input from "./ui/Input";
 import Label from "./ui/Label";
 
 function Login({ onLogin }) {
-  const [usuario, setUsuario] = useState("ana");
+  const [usuario, setUsuario] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   return (
@@ -32,6 +32,7 @@ function Login({ onLogin }) {
           </div>
           <Button className="w-full bg-indigo-600 text-white flex items-center justify-center gap-2" onClick={async()=>{
             try {
+              setError("");
               const user = await login(usuario, password);
               onLogin(user);
             } catch (e) {

--- a/frontend/src/components/Shell.jsx
+++ b/frontend/src/components/Shell.jsx
@@ -13,6 +13,7 @@ import {
   PieChart,
   Users,
   Car,
+  KeyRound,
 } from "lucide-react";
 import Button from "./ui/Button";
 import Card from "./ui/Card";
@@ -23,6 +24,7 @@ import Reportes from "../pages/Reportes";
 import Auditoria from "../pages/Auditoria";
 import Configuracion from "../pages/Configuracion";
 import Backups from "../pages/Backups";
+import Perfil from "../pages/Perfil";
 
 const MenuItem = ({ icon:Icon, label, active, onClick, hidden }) => hidden ? null : (
   <button onClick={onClick} className={`flex items-center gap-3 w-full text-left px-3 py-2 rounded-xl hover:bg-indigo-50 ${active?"bg-indigo-100 text-indigo-700":"text-slate-700"}`}>
@@ -34,6 +36,7 @@ function Shell({ user, onLogout }){
   const [view, setView] = useState('tablero');
   const isOperador = user?.rol === "operador";
   const isAdmin = user?.rol === "admin";
+  const canChangePwd = user?.rol === 'operador' || user?.rol === 'supervisor';
   return (
     <div className="min-h-screen bg-slate-50">
       <div className="sticky top-0 z-40 bg-white border-b border-slate-200">
@@ -61,6 +64,7 @@ function Shell({ user, onLogout }){
             <MenuItem icon={ShieldCheck} label="Auditoría" active={view==='auditoria'} onClick={()=>setView('auditoria')} hidden={isOperador}/>
             <MenuItem icon={Settings} label="Configuración" active={view==='config'} onClick={()=>setView('config')} hidden={!isAdmin}/>
             <MenuItem icon={Database} label="Backups" active={view==='backups'} onClick={()=>setView('backups')} hidden={!isAdmin}/>
+            <MenuItem icon={KeyRound} label="Perfil" active={view==='perfil'} onClick={()=>setView('perfil')} hidden={!canChangePwd}/>
           </div>
         </Card>
         <div className="col-span-9 space-y-6">
@@ -70,6 +74,7 @@ function Shell({ user, onLogout }){
           {view==='auditoria' && <Auditoria/>}
           {view==='config' && <Configuracion/>}
           {view==='backups' && <Backups/>}
+          {view==='perfil' && <Perfil user={user}/>}
         </div>
       </div>
     </div>

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -19,3 +19,12 @@ export const getCars = () => apiFetch('/carros');
 export const getTramos = () => apiFetch('/tramos');
 export const getTarifaActiva = () => apiFetch('/tarifa/activa');
 export const getUsuarios = () => apiFetch('/usuarios');
+export const getRoles = () => apiFetch('/roles');
+export const createUser = (data) => apiFetch('/usuarios', { method: 'POST', body: JSON.stringify(data) });
+export const updateUser = (id, data) => apiFetch(`/usuarios/${id}`, { method: 'PATCH', body: JSON.stringify(data) });
+export const deleteUser = (id) => apiFetch(`/usuarios/${id}`, { method: 'DELETE' });
+export const changePassword = (id, oldPassword, newPassword) =>
+  apiFetch(`/usuarios/${id}/password`, {
+    method: 'PATCH',
+    body: JSON.stringify({ oldPassword, newPassword })
+  });

--- a/frontend/src/pages/Configuracion.jsx
+++ b/frontend/src/pages/Configuracion.jsx
@@ -5,7 +5,7 @@ import Button from "../components/ui/Button";
 import Input from "../components/ui/Input";
 import Label from "../components/ui/Label";
 import Pill from "../components/ui/Pill";
-import { getTramos, getCars, getUsuarios, getTarifaActiva } from "../lib/api";
+import { getTramos, getCars, getUsuarios, getTarifaActiva, getRoles, createUser, updateUser, deleteUser } from "../lib/api";
 
 const Section = ({ title, children, actions }) => (
   <Card className="p-4">
@@ -22,13 +22,56 @@ function Configuracion(){
   const [cars, setCars] = useState([]);
   const [usuarios, setUsuarios] = useState([]);
   const [tarifa, setTarifa] = useState(0);
+  const [roles, setRoles] = useState([]);
 
   useEffect(()=>{
     getTramos().then(setTramos);
     getCars().then(setCars);
     getUsuarios().then(setUsuarios);
     getTarifaActiva().then(t=>setTarifa(t?.monto ?? 0));
+    getRoles().then(setRoles);
   },[]);
+
+  const findRole = (nombre) => roles.find(r => r.nombre.toLowerCase() === nombre.toLowerCase());
+
+  const handleNuevo = async () => {
+    const username = prompt('Usuario');
+    if(!username) return;
+    const password = prompt('Contraseña');
+    if(!password) return;
+    const roleName = prompt('Rol (Admin/Supervisor/Operador)');
+    const role = findRole(roleName || '');
+    if(!role) return alert('Rol inválido');
+    try {
+      const u = await createUser({ username, password, role_id: role.id, activo: 1 });
+      setUsuarios([...usuarios, { ...u, role: role.nombre }]);
+    } catch(e){ alert(e.message); }
+  };
+
+  const handleEdit = async (u) => {
+    const roleName = prompt('Rol (Admin/Supervisor/Operador)', u.role);
+    const role = findRole(roleName || '');
+    if(!role) return alert('Rol inválido');
+    try {
+      await updateUser(u.id, { role_id: role.id });
+      setUsuarios(usuarios.map(x=>x.id===u.id ? { ...x, role: role.nombre, role_id: role.id } : x));
+    } catch(e){ alert(e.message); }
+  };
+
+  const toggleActivo = async (u) => {
+    try {
+      const updated = await updateUser(u.id, { activo: u.activo ? 0 : 1 });
+      setUsuarios(usuarios.map(x=>x.id===u.id ? { ...x, activo: updated.activo } : x));
+    } catch(e){ alert(e.message); }
+  };
+
+  const handleDelete = async (u) => {
+    if(!confirm('Eliminar usuario?')) return;
+    try {
+      await deleteUser(u.id);
+      setUsuarios(usuarios.filter(x=>x.id!==u.id));
+    } catch(e){ alert(e.message); }
+  };
 
   return (
     <div className="space-y-4">
@@ -91,18 +134,23 @@ function Configuracion(){
         </div>
       </Section>
 
-      <Section title="Usuarios y roles" actions={<Button className="bg-slate-100 flex items-center gap-2"><Plus size={16}/> Nuevo</Button>}>
+      <Section title="Usuarios y roles" actions={<Button className="bg-slate-100 flex items-center gap-2" onClick={handleNuevo}><Plus size={16}/> Nuevo</Button>}>
         <div className="overflow-auto">
           <table className="w-full text-sm">
             <thead>
-              <tr className="text-left text-slate-500"><th className="py-2">Usuario</th><th>Rol</th><th></th></tr>
+              <tr className="text-left text-slate-500"><th className="py-2">Usuario</th><th>Rol</th><th>Activo</th><th></th></tr>
             </thead>
             <tbody>
               {usuarios.map(u=> (
                 <tr key={u.id} className="border-t">
                   <td className="py-2">{u.username}</td>
                   <td><Pill tone={u.role==='Admin'? 'indigo' : u.role==='Supervisor'? 'amber' : 'emerald'}>{u.role}</Pill></td>
-                  <td className="text-right"><Button className="bg-slate-100 mr-2"><Edit size={14}/></Button><Button className="bg-rose-50 text-rose-700"><Trash2 size={14}/></Button></td>
+                  <td>{u.activo ? 'Sí' : 'No'}</td>
+                  <td className="text-right">
+                    <Button className="bg-slate-100 mr-2" onClick={()=>handleEdit(u)}><Edit size={14}/></Button>
+                    <Button className="bg-slate-100 mr-2" onClick={()=>toggleActivo(u)}>{u.activo ? 'Desactivar' : 'Activar'}</Button>
+                    <Button className="bg-rose-50 text-rose-700" onClick={()=>handleDelete(u)}><Trash2 size={14}/></Button>
+                  </td>
                 </tr>
               ))}
             </tbody>

--- a/frontend/src/pages/Perfil.jsx
+++ b/frontend/src/pages/Perfil.jsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import Card from "../components/ui/Card";
+import Input from "../components/ui/Input";
+import Label from "../components/ui/Label";
+import Button from "../components/ui/Button";
+import { changePassword } from "../lib/api";
+
+function Perfil({ user }) {
+  const [actual, setActual] = useState("");
+  const [nueva, setNueva] = useState("");
+  const [confirmar, setConfirmar] = useState("");
+  const [error, setError] = useState("");
+  const [ok, setOk] = useState("");
+
+  const handle = async () => {
+    setError("");
+    setOk("");
+    if (nueva !== confirmar) {
+      setError("Las contraseñas no coinciden");
+      return;
+    }
+    try {
+      await changePassword(user.id, actual, nueva);
+      setOk("Contraseña actualizada");
+      setActual("");
+      setNueva("");
+      setConfirmar("");
+    } catch (e) {
+      setError(e.message);
+    }
+  };
+
+  return (
+    <Card className="p-6 max-w-md">
+      <div className="space-y-4">
+        <h4 className="font-semibold">Cambiar contraseña</h4>
+        {error && <div className="text-red-600 text-sm">{error}</div>}
+        {ok && <div className="text-emerald-600 text-sm">{ok}</div>}
+        <div className="space-y-2">
+          <Label>Contraseña actual</Label>
+          <Input type="password" value={actual} onChange={e=>setActual(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label>Nueva contraseña</Label>
+          <Input type="password" value={nueva} onChange={e=>setNueva(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label>Confirmar nueva contraseña</Label>
+          <Input type="password" value={confirmar} onChange={e=>setConfirmar(e.target.value)} />
+        </div>
+        <Button className="bg-indigo-600 text-white" onClick={handle}>Guardar</Button>
+      </div>
+    </Card>
+  );
+}
+
+export default Perfil;


### PR DESCRIPTION
## Summary
- Distinguish invalid user and password during login
- Allow supervisors and operators to update their own passwords via new profile page
- Enable admin to manage users with create/edit/delete and activation controls

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68ba18e8f88083319036cb1f95b9548e