### PR TITLE
Show start rental button for active cars

### DIFF
--- a/frontend/src/pages/Tablero.jsx
+++ b/frontend/src/pages/Tablero.jsx
@@ -84,7 +84,15 @@ function Tablero({ user }){
     return ()=>clearInterval(t);
   },[]);
   useEffect(()=>{
-    getCars().then(setCars);
+    getCars().then(cs=>{
+      const mapped = cs.map(c=>({
+        ...c,
+        estado: c.estado === 'activo' ? 'disponible'
+              : c.estado === 'inactivo' ? 'mantenimiento'
+              : c.estado
+      }));
+      setCars(mapped);
+    });
     getTramos().then(d=>{ setTramos(d); if(d.length>0) setStartTramo(d[0].id); });
     getTarifaActiva().then(t=>setTarifa(t?.monto ?? 0));
   },[]);


### PR DESCRIPTION
## Summary
- Map backend car states to front-end equivalents so cars marked `activo` display the start rental button

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68bb694e7b6c833192fa692778309ffd