### PR TITLE
Add rental reporting and shift closure endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,21 @@ El código fuente se encuentra en el directorio `frontend`.
 API desarrollada en [Node.js](https://nodejs.org/) usando
 [Express](https://expressjs.com/) con conexión a una base de datos
 [SQLite](https://www.sqlite.org/index.html). El código fuente se encuentra en
-el directorio `backend`.
+ el directorio `backend`.
+
+## Reportes
+
+El backend expone varias rutas para obtener listados y estadísticas de los
+alquileres. Todos los endpoints devuelven JSON por defecto y soportan los
+parámetros `?format=csv` o `?format=xlsx` para descargar la información.
+
+- `GET /reportes/alquileres-dia?fecha=YYYY-MM-DD`: alquileres de la fecha y
+  conteo total.
+- `GET /reportes/metodos-pago?desde=YYYY-MM-DD&hasta=YYYY-MM-DD`: cantidades y
+  montos por método de pago.
+- `GET /reportes/ingresos?periodo=diario|semanal|mensual`: sumatoria de ingresos
+  por período.
+- `GET /reportes/ocupacion?desde=YYYY-MM-DD&hasta=YYYY-MM-DD`: tiempo en uso vs
+  disponible por carro.
+- `POST /cierres-turno`: registra el cierre de turno de un operador y los
+  totales asociados.

--- a/backend/src/initDb.js
+++ b/backend/src/initDb.js
@@ -87,6 +87,15 @@ async function createTables() {
     FOREIGN KEY (tramo_id) REFERENCES tramos(id),
     FOREIGN KEY (operador_id) REFERENCES usuarios(id)
   );`)
+
+  await runAsync(`CREATE TABLE IF NOT EXISTS cierres_turno (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    operador_id INTEGER NOT NULL,
+    fecha TEXT NOT NULL,
+    total_alquileres INTEGER NOT NULL DEFAULT 0,
+    total_monto REAL NOT NULL DEFAULT 0,
+    FOREIGN KEY (operador_id) REFERENCES usuarios(id)
+  );`)
 }
 
 async function seedData() {


### PR DESCRIPTION
## Summary
- add CSV/XLSX export helpers and reporting routes (daily rentals, payment methods, revenue, occupancy)
- implement shift closing endpoint and backing table
- document available report endpoints

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbab52bc0083319e1a54d4f87a7f02