### PR TITLE
Improve rental flows and add tariff management

### DIFF
--- a/frontend/src/components/ui/Input.jsx
+++ b/frontend/src/components/ui/Input.jsx
@@ -1,7 +1,27 @@
-const Input = ({ className = "", ...props }) => (
-  <input
-    className={`w-full rounded-xl border border-slate-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500 ${className}`}
-    {...props}
-  />
-);
+import { useState } from "react";
+import { Eye, EyeOff } from "lucide-react";
+
+const Input = ({ className = "", type = "text", ...props }) => {
+  const [show, setShow] = useState(false);
+  const isPassword = type === "password";
+  return (
+    <div className={`relative w-full ${className}`}>
+      <input
+        className={`w-full rounded-xl border border-slate-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500 ${isPassword ? "pr-10" : ""}`}
+        type={isPassword && show ? "text" : type}
+        {...props}
+      />
+      {isPassword && (
+        <button
+          type="button"
+          className="absolute inset-y-0 right-0 px-3 flex items-center text-slate-500"
+          onClick={() => setShow((s) => !s)}
+        >
+          {show ? <EyeOff size={16} /> : <Eye size={16} />}
+        </button>
+      )}
+    </div>
+  );
+};
+
 export default Input;

--- a/frontend/src/components/ui/Modal.jsx
+++ b/frontend/src/components/ui/Modal.jsx
@@ -5,7 +5,7 @@ const Modal = ({ open, onClose, title, children, footer }) => {
   if (!open) return null;
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-      <Card className="w-full max-w-xl">
+      <Card className="w-full max-w-xl overflow-hidden">
         <div className="flex items-center justify-between p-4 border-b">
           <h3 className="text-lg font-semibold">{title}</h3>
           <Button className="bg-slate-100" onClick={onClose}>Cerrar</Button>

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -18,6 +18,7 @@ export const login = (username, password) =>
 export const getCars = () => apiFetch('/carros');
 export const getTramos = () => apiFetch('/tramos');
 export const getTarifaActiva = () => apiFetch('/tarifa/activa');
+export const setTarifa = (data) => apiFetch('/tarifa', { method: 'POST', body: JSON.stringify(data) });
 export const getUsuarios = () => apiFetch('/usuarios');
 export const getRoles = () => apiFetch('/roles');
 export const createUser = (data) => apiFetch('/usuarios', { method: 'POST', body: JSON.stringify(data) });


### PR DESCRIPTION
## Summary
- hide maintenance cars from operators and use local time for rentals
- add password visibility toggle and rounded modal
- allow admins to update global tariff for all roles

## Testing
- `npm test`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbb00bf164833195d17e0988c36927