### PR TITLE
feat: persist active rentals

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -299,6 +299,19 @@ app.post('/alquileres/:id/finalizar', async (req, res) => {
   }
 })
 
+app.get('/alquileres/activos', async (_req, res) => {
+  try {
+    const rows = await allAsync(
+      `SELECT a.id, a.carro_id, a.tramo_id, a.inicio, a.costo, a.estado, t.minutos
+       FROM alquileres a JOIN tramos t ON t.id = a.tramo_id
+       WHERE a.estado = "activo"`
+    )
+    res.json(rows)
+  } catch (e) {
+    res.status(500).json({ error: e.message })
+  }
+})
+
 // Rutas: Reportes
 app.get('/reportes/alquileres-dia', async (req, res) => {
   try {

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -42,6 +42,7 @@ export const updateCar = (id, data) => apiFetch(`/carros/${id}`, { method: 'PATC
 // Alquileres
 export const startRental = (data) => apiFetch('/alquileres', { method: 'POST', body: JSON.stringify(data) });
 export const endRental = (id, data) => apiFetch(`/alquileres/${id}/finalizar`, { method: 'POST', body: JSON.stringify(data) });
+export const getActiveRentals = () => apiFetch('/alquileres/activos');
 export const getRentalsDay = (fecha) => {
   const query = fecha ? `?fecha=${fecha}` : '';
   return apiFetch(`/reportes/alquileres-dia${query}`);

--- a/frontend/src/pages/Tablero.jsx
+++ b/frontend/src/pages/Tablero.jsx
@@ -8,7 +8,7 @@ import Select from "../components/ui/Select";
 import Label from "../components/ui/Label";
 import Modal from "../components/ui/Modal";
 import { formatoMoneda } from "../lib/data";
-import { getCars, getTramos, getTarifaActiva, startRental, endRental, updateCar } from "../lib/api";
+import { getCars, getTramos, getTarifaActiva, startRental, endRental, updateCar, getActiveRentals } from "../lib/api";
 
 function Countdown({ seconds }){
   const m = Math.floor(seconds/60).toString().padStart(2,'0');
@@ -103,6 +103,18 @@ function Tablero({ user }){
     });
     getTramos().then(d=>{ setTramos(d); if(d.length>0) setStartTramo(d[0].id); });
     getTarifaActiva().then(t=>setTarifa(t?.monto ?? 0));
+    getActiveRentals().then(rs=>{
+      setAlquileres(rs.map(a=>({
+        id:a.id,
+        carroId:a.carro_id,
+        tramoId:a.tramo_id,
+        inicio:new Date(a.inicio),
+        fin:new Date(new Date(a.inicio).getTime()+a.minutos*60000),
+        costo:a.costo,
+        estado:a.estado,
+        alertado:false
+      })));
+    });
   },[]);
 
   const activos = useMemo(()=>alquileres.filter(a=>a.estado==='activo'), [alquileres]);


### PR DESCRIPTION
## Summary
- expose `/alquileres/activos` endpoint to list active rentals
- load active rentals on dashboard to keep countdowns after navigation

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bce93634f8833193c822349d978efb