### PR TITLE
Fix rental export to Excel to show times

### DIFF
--- a/frontend/src/lib/exportExcel.js
+++ b/frontend/src/lib/exportExcel.js
@@ -20,8 +20,13 @@ export async function exportRentalsExcel(rows = []) {
 
   const parseTime = (t) => {
     if (!t) return null;
-    const [h, m] = t.split(':').map(Number);
-    return new Date(1970, 0, 1, h, m);
+    const date = new Date(t);
+    if (!isNaN(date)) return date;
+    const [h, m] = String(t).split(':').map(Number);
+    if (Number.isFinite(h) && Number.isFinite(m)) {
+      return new Date(1970, 0, 1, h, m);
+    }
+    return null;
   };
   const parseTramo = (t) => {
     const n = parseInt(t, 10);


### PR DESCRIPTION
## Summary
- Handle ISO date strings when exporting rentals to Excel so hour values appear

## Testing
- `npm test` (frontend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68bcf98b7a988331984d03bac6950f86